### PR TITLE
More bugfixes

### DIFF
--- a/Assets/Prefabs/Blocks/RespawnBlockPrefab.prefab
+++ b/Assets/Prefabs/Blocks/RespawnBlockPrefab.prefab
@@ -107,4 +107,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   lifeTime: 0.8
   destructionTexture: {fileID: 2800000, guid: 5a0c8954d3611734cbf23cd5cb16acb6, type: 3}
-  respawnTime: 1
+  respawnTime: 1.5

--- a/Assets/Prefabs/Blocks/StoneBlockPrefeb.prefab
+++ b/Assets/Prefabs/Blocks/StoneBlockPrefeb.prefab
@@ -106,7 +106,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 946430ba5d246a741ad5eade5392e961, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  lifeTime: 1.2
+  lifeTime: 1.5
   destructionTexture: {fileID: 2800000, guid: c7ec999327202354a86aa34da73b7a36, type: 3}
   audioClip: {fileID: 8300000, guid: e3ef82bdb27025046a710055ac9f6d32, type: 3}
 --- !u!82 &-341853126093334359

--- a/Assets/Prefabs/Player/Advisor.prefab
+++ b/Assets/Prefabs/Player/Advisor.prefab
@@ -265,7 +265,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 8.9, y: 4.2}
+  m_AnchoredPosition: {x: 12.9, y: 7.3}
   m_SizeDelta: {x: 25, y: 25}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1083252809

--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -2155,6 +2155,7 @@ MonoBehaviour:
   sprintVelocity: 4
   fallVelocityLimit: 10
   jumpVelocity: 6.5
+  ShoesRenderer: {fileID: 7947623378067440636}
   fallAccelaration: -20
   riseAcceleration: -10
   updraftAcceleration: -10

--- a/Assets/Scripts/Blocks/Block.cs
+++ b/Assets/Scripts/Blocks/Block.cs
@@ -30,6 +30,7 @@ public abstract class Block : MonoBehaviour
     [SerializeField] public Texture destructionTexture;
     private Texture recoveryTexture;
 
+    private Coroutine blockDestructionCoroutine;
     #region Initialization / Destruction
     /// <summary>
     /// Sets the BlockData of a block and initializes the block (e.g. id for group blocks / timers for charge)
@@ -54,7 +55,7 @@ public abstract class Block : MonoBehaviour
     public void StartBlockDestructionCoroutine()
     {
         // Start destruction coroutine
-        StartCoroutine(StartBlockDestruction());
+        blockDestructionCoroutine = StartCoroutine(StartBlockDestruction());
     }
 
     public void StartInstantBlockDestruction()
@@ -67,6 +68,11 @@ public abstract class Block : MonoBehaviour
     /// </summary>
     public virtual void ResetBlock()
     {
+        if (blockDestructionCoroutine != null)
+        {
+            StopCoroutine(blockDestructionCoroutine);
+            gameObject.GetComponent<Renderer>().material.mainTexture = recoveryTexture;
+        }
         this.gameObject.SetActive(true);
         lifeTime = currentLifeTime;
     }
@@ -80,7 +86,7 @@ public abstract class Block : MonoBehaviour
     {
         isTouchingPlayer = true;
         if(Gamemaster.Instance.GetPlayer().canDestroy)
-            StartCoroutine(StartBlockDestruction());
+            blockDestructionCoroutine = StartCoroutine(StartBlockDestruction());
     }
 
     /// <summary>

--- a/Assets/Scripts/Blocks/Block.cs
+++ b/Assets/Scripts/Blocks/Block.cs
@@ -58,7 +58,7 @@ public abstract class Block : MonoBehaviour
         blockDestructionCoroutine = StartCoroutine(StartBlockDestruction());
     }
 
-    public void StartInstantBlockDestruction()//Why do we have this method?
+    public void StartInstantBlockDestruction()
     {
         DestroyBlock();
     }

--- a/Assets/Scripts/Blocks/Block.cs
+++ b/Assets/Scripts/Blocks/Block.cs
@@ -58,7 +58,7 @@ public abstract class Block : MonoBehaviour
         blockDestructionCoroutine = StartCoroutine(StartBlockDestruction());
     }
 
-    public void StartInstantBlockDestruction()
+    public void StartInstantBlockDestruction()//Why do we have this method?
     {
         DestroyBlock();
     }
@@ -85,6 +85,8 @@ public abstract class Block : MonoBehaviour
     protected virtual void OnTouch(GameObject player)
     {
         isTouchingPlayer = true;
+        if (TouchedOnGoal())
+            return;
         if(Gamemaster.Instance.GetPlayer().canDestroy)
             blockDestructionCoroutine = StartCoroutine(StartBlockDestruction());
     }
@@ -115,6 +117,16 @@ public abstract class Block : MonoBehaviour
     #endregion
 
     #region Helper
+
+    protected bool TouchedOnGoal()
+    {
+        if (Gamemaster.Instance.GetPlayer().IsOnGoal)
+        {
+            DestroyBlock();
+            return true;
+        }
+        return false;
+    }
 
     protected virtual void SpawnDestructionEffect()
     {

--- a/Assets/Scripts/Blocks/ChainBlock.cs
+++ b/Assets/Scripts/Blocks/ChainBlock.cs
@@ -36,7 +36,8 @@ public class ChainBlock : Block
     protected override void OnTouch(GameObject player)
     {
         //base.OnTouch(player);
-
+        if (TouchedOnGoal())
+            return;
         if (!Gamemaster.Instance.GetPlayer().canDestroy)
             return;
 

--- a/Assets/Scripts/Blocks/ChargeBlock.cs
+++ b/Assets/Scripts/Blocks/ChargeBlock.cs
@@ -44,6 +44,8 @@ public class ChargeBlock : Block
 
     protected override void OnTouch(GameObject player)
     {
+        if (TouchedOnGoal())
+            return;
         base.OnTouch(player);
         if (Gamemaster.Instance.GetPlayer().canDestroy)
         {

--- a/Assets/Scripts/Blocks/DeathBlock.cs
+++ b/Assets/Scripts/Blocks/DeathBlock.cs
@@ -30,6 +30,8 @@ public class DeathBlock : Block
 
     protected override void OnTouch(GameObject player)
     {
+        if (TouchedOnGoal())
+            return;
         // GameObject.FindGameObjectWithTag(TagDictionary.PlayScene).GetComponent<PlayScene>().KillPlayer();
         GameObject.FindObjectOfType<PlayScene>().KillPlayer();
     }

--- a/Assets/Scripts/Blocks/GoalBlock.cs
+++ b/Assets/Scripts/Blocks/GoalBlock.cs
@@ -11,7 +11,16 @@ public class GoalBlock : Block
 
     protected override void OnTouch(GameObject player)
     {
-        if(player.transform.position.y > this.transform.position.y)
+        Player playerScript = player.GetComponent<Player>();
+        if (playerScript.IsOnGoal)
+            return;
+        float goalX = Gamemaster.Instance.GetLevel().GetLevelData().GoalPlatformCoordinates.x * Block_Data.BlockSize;
+        float goalMargin = 1.5f * Block_Data.BlockSize;
+        float modelXPos = playerScript.ShoesRenderer.bounds.center.x;
+        float modelOffset = playerScript.ShoesRenderer.bounds.extents.x / 2f;
+        if (player.transform.position.y > this.transform.position.y 
+            && modelXPos + modelOffset >= goalX - goalMargin 
+            && modelXPos - modelOffset <= goalX + goalMargin)
         {
             ReachedGoal();
         }
@@ -30,5 +39,14 @@ public class GoalBlock : Block
             Gamemaster.Instance.GetLevel().GetLevelData(). IsExportable = true;
     }
 
+    #endregion
+    #region ContinousHandling
+    protected void OnTriggerStay(Collider collider)
+    {
+        if (collider.gameObject.tag == TagDictionary.Player)
+        {
+            OnTouch(collider.gameObject);
+        }
+    }
     #endregion
 }

--- a/Assets/Scripts/Blocks/KeyBlock.cs
+++ b/Assets/Scripts/Blocks/KeyBlock.cs
@@ -43,6 +43,8 @@ public class KeyBlock : Block
 
     protected override void OnTouch(GameObject player)
     {
+        if (TouchedOnGoal())
+            return;
         // If the player is able to destroy blocks
         if (Gamemaster.Instance.GetPlayer().canDestroy)
         {

--- a/Assets/Scripts/Blocks/LockBlock.cs
+++ b/Assets/Scripts/Blocks/LockBlock.cs
@@ -47,6 +47,8 @@ public class LockBlock : Block
 
     protected override void OnTouch(GameObject player)
     {
+        if (TouchedOnGoal())
+            return;
         // If the the lockBlock is unlocked
         if (!((LockBlock_Data)BlockData).GetLock())
         {

--- a/Assets/Scripts/Blocks/RestoreBlock.cs
+++ b/Assets/Scripts/Blocks/RestoreBlock.cs
@@ -43,6 +43,8 @@ public class RestoreBlock : Block
 
     protected override void OnTouch(GameObject player)
     {
+        if (TouchedOnGoal())
+            return;
         // If the player is able to destroy blocks
         if (Gamemaster.Instance.GetPlayer().canDestroy)
         {

--- a/Assets/Scripts/Blocks/RestoreableBlock.cs
+++ b/Assets/Scripts/Blocks/RestoreableBlock.cs
@@ -49,6 +49,8 @@ public class RestoreableBlock : Block
 
     protected override void OnTouch(GameObject player)
     {
+        if (TouchedOnGoal())
+            return;
         // Destroy the lockBlock
         base.OnTouch(player);
     }

--- a/Assets/Scripts/Blocks/StartBlock.cs
+++ b/Assets/Scripts/Blocks/StartBlock.cs
@@ -11,7 +11,8 @@ public class StartBlock : Block
     
     protected override void OnTouch(GameObject player)
     {
-
+        if (TouchedOnGoal())
+            return;
     }
 
     protected override void OnTouchEnd(GameObject player)

--- a/Assets/Scripts/Blocks/StoneBlock.cs
+++ b/Assets/Scripts/Blocks/StoneBlock.cs
@@ -37,6 +37,8 @@ public class StoneBlock : Block
 
     protected override void OnTouch(GameObject player)
     {
+        if (TouchedOnGoal())
+            return;
         if (Gamemaster.Instance.GetPlayer().canDestroy)
         {
             audioSource.PlayOneShot(audioClip, Random.Range(0.5f, 1.5f));

--- a/Assets/Scripts/Blocks/UpdraftBlock.cs
+++ b/Assets/Scripts/Blocks/UpdraftBlock.cs
@@ -54,6 +54,8 @@ public class UpdraftBlock : Block
 
     protected override void OnTouch(GameObject player)
     {
+        if (TouchedOnGoal())
+            return;
         base.OnTouch(player);
         
         Player playerScript = player.GetComponent<Player>();

--- a/Assets/Scripts/Blocks/WoodBlock.cs
+++ b/Assets/Scripts/Blocks/WoodBlock.cs
@@ -38,6 +38,8 @@ public class WoodBlock : Block
 
     protected override void OnTouch(GameObject player)
     {
+        if (TouchedOnGoal())
+            return;
         if (Gamemaster.Instance.GetPlayer().canDestroy)
         {
             audioSource.PlayOneShot(audioClip, Random.Range(0.5f, 1.5f));

--- a/Assets/Scripts/Input/InputMethod.cs
+++ b/Assets/Scripts/Input/InputMethod.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 public abstract class InputMethod : MonoBehaviour
 {
     public abstract float GetHorizontalDirection();
+    public abstract bool PressedInteract();
     public abstract bool PressedJump();
     public abstract bool ReleasedJump();
     public abstract bool PressedExitButton();

--- a/Assets/Scripts/Input/MouseAndKeyboardInput.cs
+++ b/Assets/Scripts/Input/MouseAndKeyboardInput.cs
@@ -70,7 +70,7 @@ public class MouseAndKeyboardInput : InputMethod
             pressedJumpButton = PressedJumpButton.None;
             return true;
         }
-        return false;   
+        return false;
     }
 
     public override bool PressedZoomButton()
@@ -87,5 +87,11 @@ public class MouseAndKeyboardInput : InputMethod
     {
         return Input.GetKeyDown(KeyCode.Return);
     }
+
+    public override bool PressedInteract()
+    {
+        return Input.GetButtonDown(InputDictionary.Jump);
+    }
+
 }
 

--- a/Assets/Scripts/Input/MouseAndKeyboardInput.cs
+++ b/Assets/Scripts/Input/MouseAndKeyboardInput.cs
@@ -9,6 +9,11 @@ public class MouseAndKeyboardInput : InputMethod
     private enum PressedJumpButton { None, Space, W, Up };
     private PressedJumpButton pressedJumpButton = PressedJumpButton.None;
 
+    private void OnDisable()
+    {
+        pressedJumpButton = PressedJumpButton.None;
+    }
+
     public override float GetHorizontalDirection()
     {
         return Input.GetAxisRaw(InputDictionary.Horizontal);

--- a/Assets/Scripts/Input/Player.cs
+++ b/Assets/Scripts/Input/Player.cs
@@ -13,7 +13,7 @@ public class Player : DialogueParticipant
     public float sprintVelocity;
     public float fallVelocityLimit;
     public float jumpVelocity;
-
+    public Renderer ShoesRenderer;
     [SerializeField] private float fallAccelaration;
     [SerializeField] private float riseAcceleration;
     [SerializeField] private float updraftAcceleration;

--- a/Assets/Scripts/Input/Player.cs
+++ b/Assets/Scripts/Input/Player.cs
@@ -363,6 +363,11 @@ public class Player : DialogueParticipant
     #endregion
 
     #region Interaction/Dialogue
+
+    public bool IsGrounded()
+    {
+        return grounded;
+    }
     public void Interact()
     {
         dialogueManager.HandlePlayerInteraction();

--- a/Assets/Scripts/Input/Player.cs
+++ b/Assets/Scripts/Input/Player.cs
@@ -324,7 +324,9 @@ public class Player : DialogueParticipant
     public void ReachGoalPlatform()
     {
         Vector2Int goalPlatformPosition = Gamemaster.Instance.GetLevel().GetLevelData().GoalPlatformCoordinates;
-        this.GetComponent<Collider>().enabled = false;
+        Vector3 colSize = this.GetComponent<BoxCollider>().size;
+        colSize.x *= 3;
+        this.GetComponent<BoxCollider>().size = colSize;
         IsOnGoal = true;
         goalPosition = new Vector3(goalPlatformPosition.x, goalPlatformPosition.y + (Block_Data.BlockSize + height) / 2f, 0);
         StartCoroutine(GoalAnimation());

--- a/Assets/Scripts/Input/PlayerInputHandler.cs
+++ b/Assets/Scripts/Input/PlayerInputHandler.cs
@@ -45,8 +45,11 @@ public class PlayerInputHandler : MonoBehaviour
 
         if (input.PressedJump())
         {
-            if (player.IsInteractingWithAdvisor)
+            if (player.IsInteractingWithAdvisor && player.IsGrounded())
+            {
                 player.Interact();
+                player.Run(0);
+            }
             else
                 player.JumpAction();
         }
@@ -59,7 +62,8 @@ public class PlayerInputHandler : MonoBehaviour
 
     private void HandleDialogueInput()
     {
-        if (input.PressedJump())
+        input.ReleasedJump();
+        if (input.PressedInteract())
         {
             player.Interact();
         }

--- a/Assets/Scripts/Input/XboxInput.cs
+++ b/Assets/Scripts/Input/XboxInput.cs
@@ -69,4 +69,10 @@ public class XboxInput : InputMethod
     {
         return Input.GetKeyDown(InputDictionary.XboxStartButton);
     }
+
+    public override bool PressedInteract()
+    {
+        return Input.GetKeyDown(InputDictionary.XboxAButton);
+    }
+    
 }

--- a/Assets/Scripts/LevelEditor/LevelEditorCamera.cs
+++ b/Assets/Scripts/LevelEditor/LevelEditorCamera.cs
@@ -47,8 +47,8 @@ public class LevelEditorCamera : MonoBehaviour
 
         if (mouseScroll)
         {
-            horizontal = (Input.mousePosition.x - mouseScrollStart.x) / Screen.width * mouseSpeedMultiplier;
-            vertical = (Input.mousePosition.y - mouseScrollStart.y) / Screen.height * mouseSpeedMultiplier;
+            horizontal = -(Input.mousePosition.x - mouseScrollStart.x) / Screen.width * mouseSpeedMultiplier;
+            vertical = -(Input.mousePosition.y - mouseScrollStart.y) / Screen.height * mouseSpeedMultiplier;
         }
         else if(!nameInputField.isFocused)
         {

--- a/Assets/Scripts/PlayScene/PlayAdditionalInput.cs
+++ b/Assets/Scripts/PlayScene/PlayAdditionalInput.cs
@@ -30,28 +30,29 @@ public class PlayAdditionalInput : MonoBehaviour
 
     void Update()
     {
-					
+
         if (playerInputHandler.IsInDialogue) //Prevent any additional inputs during dialogues
+        {
+            if (input.ReleasedZoomButton())
+            {
+                camControl.StartZoomIn();
+            }
             return;
+        }
+            
 
         if (!playUI.IsOpen)
-		{
-			if (input.PressedZoomButton())
-			{
-				camControl.StartZoomOut();
-			}
-			else if (input.ReleasedZoomButton())
-			{
-				if (input.PressedZoomButton())
-				{
-					camControl.StartZoomOut();
-				}
-				else if (input.ReleasedZoomButton())
-				{
-					camControl.StartZoomIn();
-				}
-			}
-            
+        {
+
+            if (input.PressedZoomButton())
+            {
+                camControl.StartZoomOut();
+            }
+            else if (input.ReleasedZoomButton())
+            {
+                camControl.StartZoomIn();
+            }
+
             if (input.PressedExitButton())
             {
                 SceneManager.LoadScene(Gamemaster.Instance.GetLevelType() == LevelType.Test ? SceneDictionary.LevelEditor : SceneDictionary.MainMenu);

--- a/Assets/Scripts/PlayScene/PlayScene.cs
+++ b/Assets/Scripts/PlayScene/PlayScene.cs
@@ -48,6 +48,7 @@ public class PlayScene : MonoBehaviour
 
     private IEnumerator PlayerDeath()
     {
+        StopForceOutbreak();
         advisor?.HandlePlayerDeath();
         running = false;
         player.gameObject.SetActive(false);
@@ -99,10 +100,11 @@ public class PlayScene : MonoBehaviour
     private IEnumerator ForceOutbreak(float chargeTime, float outbreakRadius, ParticleSystem forceOutbreak)
     {
         yield return new WaitForSeconds(chargeTime);
-
+        
         // Get the player
         Player player = Gamemaster.Instance.GetPlayer();
-
+        if (player.IsOnGoal)
+            yield break;
         // Get all colliders that overlap a sphere of radius = outbreakRadius
         Collider[] hitColliders = Physics.OverlapSphere(player.transform.position, outbreakRadius);
 

--- a/Assets/Scripts/Utilities/SetCanvasShader.cs
+++ b/Assets/Scripts/Utilities/SetCanvasShader.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SetCanvasShader : MonoBehaviour
+{
+    [SerializeField] private Shader shader;
+
+    private void Awake()
+    {
+        if (shader)
+            Canvas.GetDefaultCanvasMaterial().shader = shader;
+    }
+}

--- a/Assets/Scripts/Utilities/SetCanvasShader.cs.meta
+++ b/Assets/Scripts/Utilities/SetCanvasShader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a948033e8a514fe4ca4be789f0e150e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shader.meta
+++ b/Assets/Shader.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4a752540859c0e7459b3e36dbe8699c4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shader/UINoZTest.shader
+++ b/Assets/Shader/UINoZTest.shader
@@ -1,0 +1,93 @@
+﻿
+
+Shader "Custom/UINoZTest"
+{
+	Properties
+	{
+		[PerRendererData] _MainTex("Sprite Texture", 2D) = "white" {}
+		_Color("Tint", Color) = (1,1,1,1)
+
+		_StencilComp("Stencil Comparison", Float) = 8
+		_Stencil("Stencil ID", Float) = 0
+		_StencilOp("Stencil Operation", Float) = 0
+		_StencilWriteMask("Stencil Write Mask", Float) = 255
+		_StencilReadMask("Stencil Read Mask", Float) = 255
+
+		_ColorMask("Color Mask", Float) = 15
+	}
+
+		SubShader
+		{
+			Tags
+			{
+				"Queue" = "Overlay"
+				"IgnoreProjector" = "True"
+				"RenderType" = "Transparent"
+				"PreviewType" = "Plane"
+				"CanUseSpriteAtlas" = "True"
+			}
+
+			Stencil
+			{
+				Ref[_Stencil]
+				Comp[_StencilComp]
+				Pass[_StencilOp]
+				ReadMask[_StencilReadMask]
+				WriteMask[_StencilWriteMask]
+			}
+
+			Cull Off
+			Lighting Off
+			ZWrite Off
+			ZTest Off
+			Blend SrcAlpha OneMinusSrcAlpha
+			ColorMask[_ColorMask]
+
+			Pass
+			{
+			CGPROGRAM
+				#pragma vertex vert
+				#pragma fragment frag
+				#include "UnityCG.cginc"
+
+				struct appdata_t
+				{
+					float4 vertex   : POSITION;
+					float4 color    : COLOR;
+					float2 texcoord : TEXCOORD0;
+				};
+
+				struct v2f
+				{
+					float4 vertex   : SV_POSITION;
+					fixed4 color : COLOR;
+					half2 texcoord  : TEXCOORD0;
+				};
+
+				fixed4 _Color;
+				fixed4 _TextureSampleAdd; //Added for font color support
+
+				v2f vert(appdata_t IN)
+				{
+					v2f OUT;
+					OUT.vertex = UnityObjectToClipPos(IN.vertex);
+					OUT.texcoord = IN.texcoord;
+	#ifdef UNITY_HALF_TEXEL_OFFSET
+					OUT.vertex.xy += (_ScreenParams.zw - 1.0)*float2(-1,1);
+	#endif
+					OUT.color = IN.color * _Color;
+					return OUT;
+				}
+
+				sampler2D _MainTex;
+
+				fixed4 frag(v2f IN) : SV_Target
+				{
+				half4 color = (tex2D(_MainTex, IN.texcoord) + _TextureSampleAdd) * IN.color;  //Added for font color support
+				clip(color.a - 0.01);
+				return color;
+				}
+			ENDCG
+			}
+		}
+}

--- a/Assets/Shader/UINoZTest.shader.meta
+++ b/Assets/Shader/UINoZTest.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 52531ec622c2ff34c979ee5abbb04e16
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_scenes/LevelEditor.unity
+++ b/Assets/_scenes/LevelEditor.unity
@@ -202,7 +202,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 362844010}
   m_Direction: 2
   m_Value: 1
-  m_Size: 0.5
+  m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -2777,7 +2777,7 @@ MonoBehaviour:
   canvas: {fileID: 1507724821}
   menuBar: {fileID: 1022902141}
   blockSelection: {fileID: 1245070847}
-  keyboardSpeedMultiplier: 1.5
+  keyboardSpeedMultiplier: 1.8
   mouseSpeedMultiplier: 3
   zoomSpeed: 1
   minZoom: 5

--- a/Assets/_scenes/PlayScene.unity
+++ b/Assets/_scenes/PlayScene.unity
@@ -2234,6 +2234,50 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1671169927}
   m_CullTransparentMesh: 0
+--- !u!1 &1689650211
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1689650213}
+  - component: {fileID: 1689650212}
+  m_Layer: 0
+  m_Name: SetCanvasShader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1689650212
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1689650211}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a948033e8a514fe4ca4be789f0e150e6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shader: {fileID: 4800000, guid: 52531ec622c2ff34c979ee5abbb04e16, type: 3}
+--- !u!4 &1689650213
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1689650211}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.9595001, y: 3.1037502, z: 1.25}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1698162040
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Little bit more than expected:

| Bug| Solution |
| --- | --- |
| Dialogue Input did not work and some buttonHolds did not reset | Fixed - probably badly merged by me|
|Canvases for dialogues obstructed by Blocks | Added new Shader so they always render in front(Also do not place blocks 1 field to the left of startplatform -> obstructs advisor)|
| EditorCamera moved into wrong direction | Now it feels more like a drag(you can stil hold) |
|When player was dead did not register button release => could not jump for 1 press| button released on death|
|Player death can cause block to be in destruction routine and block gets destroyed after reset|Stop routine on reset|
|Goal could be reached by touching corner of goalBlock(even when block is still on it)| Better conditions using feet of player|
|Blocks on Goal can stop player from moving to center(or they clip into blocks while dancing| enlarge player collider and force destroy all blocks in contact|
|ForceOutbreak possible when player is dead or when they reached the goal| stop coroutine|
