### PR TITLE
Collider adjustment

### DIFF
--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -96,7 +96,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1993141265
 RectTransform:
   m_ObjectHideFlags: 0
@@ -182,15 +182,15 @@ RectTransform:
   m_GameObject: {fileID: 2082205146}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 2}
-  m_LocalScale: {x: 0.08333335, y: 0.04166665, z: 1}
+  m_LocalScale: {x: 0.114942536, y: 0.04166665, z: 1}
   m_Children:
   - {fileID: 1993141265}
   m_Father: {fileID: 4839093188961784831}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: -100, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0.38, y: -0.43}
+  m_AnchoredPosition: {x: 0.5241363, y: -0.43}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &2082205151
@@ -321,8 +321,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 28724416987952405}
-  m_LocalRotation: {x: -0.03810994, y: 0.36727372, z: 0.014113336, w: 0.92922467}
-  m_LocalPosition: {x: 0.0018061368, y: 0.78889734, z: -0.0031198545}
+  m_LocalRotation: {x: -0.040326647, y: 0.3660411, z: 0.014930816, w: 0.92960465}
+  m_LocalPosition: {x: 0.000954637, y: 0.79145396, z: 0.0022679553}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 3097633824538999393}
@@ -354,7 +354,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 189587827106875456}
-  m_LocalRotation: {x: -0.010058117, y: 0.003588581, z: -0.0005996437, w: 0.99994284}
+  m_LocalRotation: {x: -0.005061764, y: 0.0035303375, z: -0.00050013216, w: 0.99998087}
   m_LocalPosition: {x: -0, y: 0.08913815, z: 0.010340212}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -416,7 +416,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 277287478621777178}
-  m_LocalRotation: {x: -0.02637711, y: -0.33547708, z: -0.061725665, w: 0.9396538}
+  m_LocalRotation: {x: -0.0066048726, y: -0.33838904, z: -0.07715941, w: 0.93781435}
   m_LocalPosition: {x: 0.21769282, y: -0.0063401023, z: -0.020410933}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -447,7 +447,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 400577634492136840}
-  m_LocalRotation: {x: -0.054619566, y: -0.08923251, z: -0.2862614, w: 0.95242256}
+  m_LocalRotation: {x: -0.05696066, y: -0.09243147, z: -0.30138806, w: 0.94729996}
   m_LocalPosition: {x: 0.028813388, y: -0.00992857, z: -0.0018692748}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -857,7 +857,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1062113483863617902}
-  m_LocalRotation: {x: 0.27374128, y: 0.07846176, z: 0.024894971, w: 0.95827436}
+  m_LocalRotation: {x: 0.25396037, y: 0.080004565, z: 0.0238422, w: 0.9636052}
   m_LocalPosition: {x: 0.0040902854, y: -0.33779728, z: 0.0011150115}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -888,7 +888,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1212059516483383965}
-  m_LocalRotation: {x: -0.014357264, y: 0.035399593, z: 0.059024755, w: 0.9975254}
+  m_LocalRotation: {x: -0.017768651, y: 0.04090099, z: 0.08018233, w: 0.9957822}
   m_LocalPosition: {x: -0.032291904, y: -0.0057491474, z: -0.0014349759}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -919,7 +919,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1318864197212879558}
-  m_LocalRotation: {x: 0.0492396, y: -0.04070684, z: 0.008307762, w: 0.99792254}
+  m_LocalRotation: {x: 0.046004117, y: -0.040394627, z: 0.0074433717, w: 0.99809647}
   m_LocalPosition: {x: -0, y: 0.07722018, z: 0.011662032}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -981,7 +981,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1488192329986694925}
-  m_LocalRotation: {x: -0.045405462, y: 0.07324753, z: 0.23891453, w: 0.96720886}
+  m_LocalRotation: {x: -0.04678766, y: 0.07494877, z: 0.24793716, w: 0.9647387}
   m_LocalPosition: {x: -0.028813388, y: -0.00992857, z: -0.0018692748}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -1198,7 +1198,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2011473054245376170}
-  m_LocalRotation: {x: -0.075329386, y: 0.054698106, z: 0.002390574, w: 0.9956545}
+  m_LocalRotation: {x: -0.07487963, y: 0.05643823, z: 0.0024168314, w: 0.9955913}
   m_LocalPosition: {x: 0.044017605, y: -0.015914345, z: 0.033655696}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -1266,13 +1266,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2450014169262828258}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.072, y: 0.012, z: 0}
-  m_LocalScale: {x: 0.863937, y: 0.47999996, z: 0.863937}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.04, y: 0.011999606, z: 0}
+  m_LocalScale: {x: 1.1916372, y: 0.47999987, z: 0.863937}
   m_Children:
   - {fileID: 5006512736691705275}
   m_Father: {fileID: 4839093188961784831}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2625202291296970219
 GameObject:
@@ -1328,7 +1328,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2858510852089969158}
-  m_LocalRotation: {x: 0.0075231595, y: 0.006929901, z: -0.042167973, w: 0.9990582}
+  m_LocalRotation: {x: 0.00489638, y: 0.003241854, z: -0.057691175, w: 0.99831724}
   m_LocalPosition: {x: 0.12304863, y: -0.0040101577, z: -0.030700507}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -1465,7 +1465,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2990490146143785632}
-  m_LocalRotation: {x: -0.02882006, y: 0.053825863, z: 0.1432373, w: 0.9878033}
+  m_LocalRotation: {x: -0.03505111, y: 0.06361834, z: 0.1832124, w: 0.9803864}
   m_LocalPosition: {x: -0.03290935, y: -0.008754621, z: -0.0018692748}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -1496,7 +1496,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3058564733825388716}
-  m_LocalRotation: {x: 0.009027498, y: -0.03391074, z: 0.012964348, w: 0.99930006}
+  m_LocalRotation: {x: 0.004678474, y: -0.02164015, z: 0.019321498, w: 0.99956816}
   m_LocalPosition: {x: -0.12135157, y: -0.0003060048, z: -0.000981802}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -1527,7 +1527,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3116281820797958525}
-  m_LocalRotation: {x: 0.29117134, y: 0.11429581, z: 0.037543956, w: 0.94907653}
+  m_LocalRotation: {x: 0.28647622, y: 0.11520007, z: 0.03771723, w: 0.95038825}
   m_LocalPosition: {x: -0.0040902854, y: -0.33779728, z: 0.0011150115}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -1558,7 +1558,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3167212290854713864}
-  m_LocalRotation: {x: -0.03999594, y: -0.069177166, z: -0.22957973, w: 0.97000414}
+  m_LocalRotation: {x: -0.04405708, y: -0.075234614, z: -0.25678647, w: 0.96252763}
   m_LocalPosition: {x: 0.03290935, y: -0.008754621, z: -0.0018692748}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -1620,7 +1620,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3374272655825723291}
-  m_LocalRotation: {x: 0.0126480805, y: 0.09300664, z: 0.06953528, w: 0.9931539}
+  m_LocalRotation: {x: 0.013515347, y: 0.09153432, z: 0.069214195, w: 0.9933017}
   m_LocalPosition: {x: 0.030167103, y: -0.015619701, z: 0.021190222}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -1681,7 +1681,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3610447626400600259}
-  m_LocalRotation: {x: 0.09833416, y: -0.080912575, z: 0.017980024, w: 0.9916957}
+  m_LocalRotation: {x: 0.091894835, y: -0.08039601, z: 0.016351668, w: 0.99238324}
   m_LocalPosition: {x: -0, y: 0.09600135, z: 0.0024876622}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -1833,7 +1833,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3973184431051032604}
-  m_LocalRotation: {x: -0.0118395295, y: 0.08384922, z: -0.059247185, w: 0.9946451}
+  m_LocalRotation: {x: -0.012299779, y: 0.08851202, z: -0.040440332, w: 0.99517787}
   m_LocalPosition: {x: -0.12180294, y: -0.0013205837, z: 0.036991537}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -1864,7 +1864,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4016968052117022543}
-  m_LocalRotation: {x: -0.016322214, y: -0.060143065, z: 0.15292738, w: 0.9862706}
+  m_LocalRotation: {x: -0.023758102, y: -0.04917844, z: 0.1593118, w: 0.9857164}
   m_LocalPosition: {x: -0.1133727, y: -0.016895676, z: -0.05625614}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -1895,7 +1895,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4035638346264911153}
-  m_LocalRotation: {x: 0.21740471, y: -0.010366238, z: -0.12815315, w: 0.9675766}
+  m_LocalRotation: {x: 0.21460302, y: -0.010157323, z: -0.09356557, w: 0.97215635}
   m_LocalPosition: {x: -0.23845805, y: -0.0008520288, z: -0.008709004}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -1930,7 +1930,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4207106666217875529}
-  m_LocalRotation: {x: -0.016957985, y: -0.038503405, z: -0.08561093, w: 0.99543995}
+  m_LocalRotation: {x: -0.013008044, y: -0.032529604, z: -0.05988406, w: 0.9975904}
   m_LocalPosition: {x: 0.032291904, y: -0.0057491474, z: -0.0014349759}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -1961,7 +1961,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4444622345545638768}
-  m_LocalRotation: {x: -0.18406911, y: 0.0066686673, z: -0.14517769, w: 0.97210985}
+  m_LocalRotation: {x: -0.1746605, y: 0.0068713953, z: -0.14764157, w: 0.9734724}
   m_LocalPosition: {x: 0.0051405774, y: -0.33176798, z: -0.022845898}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -2023,7 +2023,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4755113131995938456}
-  m_LocalRotation: {x: 0.013019445, y: -0.000053099775, z: 0.058494233, w: 0.99820286}
+  m_LocalRotation: {x: 0.014219291, y: -0.016369997, z: 0.033997655, w: 0.9991867}
   m_LocalPosition: {x: -0.042158417, y: 0.16554418, z: -0.040647224}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -2063,11 +2063,11 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4839093188961783811}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1, y: 9.375, z: 0}
-  m_LocalScale: {x: 0.6, y: 1.2, z: 1}
+  m_LocalPosition: {x: 8.360001, y: 11.1, z: 0}
+  m_LocalScale: {x: 0.43500003, y: 1.2, z: 1}
   m_Children:
-  - {fileID: 1370749033330340325}
   - {fileID: 2082205147}
+  - {fileID: 1370749033330340325}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2200,7 +2200,6 @@ MonoBehaviour:
   model: {fileID: 2450014169262828258}
   IsOnGoal: 0
   IsInteractingWithAdvisor: 0
-  liftChargeFX: 0
 --- !u!54 &-5524203305601732335
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -2270,7 +2269,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5006910254950433982}
-  m_LocalRotation: {x: -0.059759706, y: -0.103895545, z: -0.3570639, w: 0.9263584}
+  m_LocalRotation: {x: -0.062069565, y: -0.10800979, z: -0.3753669, w: 0.9184666}
   m_LocalPosition: {x: 0.026790237, y: -0.009500736, z: -0.0033055397}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -2301,7 +2300,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5057533207993069993}
-  m_LocalRotation: {x: -0.010058519, y: 0.0035885521, z: -0.0005997484, w: 0.99994284}
+  m_LocalRotation: {x: -0.005061747, y: 0.003530522, z: -0.0005001469, w: 0.99998087}
   m_LocalPosition: {x: -0, y: 0.21684282, z: -0.031230537}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -2332,7 +2331,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5285123990689906388}
-  m_LocalRotation: {x: -0.10858216, y: 0.14787455, z: -0.4863555, w: 0.8542841}
+  m_LocalRotation: {x: -0.09392069, y: 0.14622729, z: -0.5055688, w: 0.84510165}
   m_LocalPosition: {x: 0.053006545, y: 0.006632174, z: -0.017092818}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -2423,7 +2422,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6273204030062565445}
-  m_LocalRotation: {x: -0.010770893, y: -0.016833168, z: 0.03566235, w: 0.9991641}
+  m_LocalRotation: {x: -0.009599104, y: -0.01264957, z: 0.04858959, w: 0.9986926}
   m_LocalPosition: {x: 0.12180294, y: -0.0013205837, z: 0.036991537}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -2454,7 +2453,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6387966888012413044}
-  m_LocalRotation: {x: 0.019216537, y: -0.07539042, z: -0.07468906, w: 0.99416727}
+  m_LocalRotation: {x: 0.018846914, y: -0.058403555, z: -0.048464704, w: 0.9969379}
   m_LocalPosition: {x: 0.042158417, y: 0.16554418, z: -0.040647224}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -2610,7 +2609,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6800037487378600601}
-  m_LocalRotation: {x: 0.082779914, y: -0.05681929, z: 0.039396703, w: 0.9941665}
+  m_LocalRotation: {x: 0.084893435, y: -0.06565532, z: 0.03819967, w: 0.99349046}
   m_LocalPosition: {x: -0.044017605, y: -0.015914345, z: 0.033655696}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -2731,7 +2730,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7419950242252383024}
-  m_LocalRotation: {x: -0.046507567, y: -0.0031127783, z: 0.061194174, w: 0.99703693}
+  m_LocalRotation: {x: -0.04677716, y: -0.0029979954, z: 0.057307627, w: 0.9972557}
   m_LocalPosition: {x: -0.0051405774, y: -0.33176798, z: -0.022845898}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -2793,7 +2792,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7608349304189290353}
-  m_LocalRotation: {x: -0.052744977, y: 0.083043054, z: 0.34538466, w: 0.9332906}
+  m_LocalRotation: {x: -0.05379176, y: 0.0845394, z: 0.35427612, w: 0.92975694}
   m_LocalPosition: {x: -0.026790237, y: -0.009500736, z: -0.0033055397}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -2945,7 +2944,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7810072143529863002}
-  m_LocalRotation: {x: -0.010672983, y: -0.0567846, z: 0.12520136, w: 0.9904475}
+  m_LocalRotation: {x: -0.017293047, y: -0.04576033, z: 0.13098854, w: 0.99017626}
   m_LocalPosition: {x: -0.12304863, y: -0.0040101577, z: -0.030700507}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -3090,7 +3089,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8834009289631297403}
-  m_LocalRotation: {x: -0.21629716, y: -0.07642495, z: -0.098259054, w: 0.9683594}
+  m_LocalRotation: {x: -0.20868918, y: -0.077504195, z: -0.09492786, w: 0.9702735}
   m_LocalPosition: {x: -0.08266982, y: -0.04795516, z: -0.0037905346}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -3121,7 +3120,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8873284813875948318}
-  m_LocalRotation: {x: -0.13785508, y: 0.08517208, z: 0.51004815, w: 0.8447441}
+  m_LocalRotation: {x: -0.131039, y: 0.08526918, z: 0.52373654, w: 0.8374115}
   m_LocalPosition: {x: -0.053006545, y: 0.006632174, z: -0.017092818}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -3152,7 +3151,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8893402153725375212}
-  m_LocalRotation: {x: -0.011271613, y: 0.12443156, z: 0.12150029, w: 0.9846966}
+  m_LocalRotation: {x: 0.0032280278, y: 0.12540294, z: 0.123643704, w: 0.98436576}
   m_LocalPosition: {x: 0.08266982, y: -0.04795516, z: -0.0037905346}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -3183,7 +3182,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8930420395323135629}
-  m_LocalRotation: {x: 0.13397913, y: -0.096118025, z: -0.10716369, w: 0.9804728}
+  m_LocalRotation: {x: 0.12126807, y: -0.08755832, z: -0.11114881, w: 0.9824833}
   m_LocalPosition: {x: 0.23845805, y: -0.0008520288, z: -0.008709004}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -3218,7 +3217,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8950701256738760822}
-  m_LocalRotation: {x: 0.054188855, y: 0.38593787, z: 0.0059917113, w: 0.92091244}
+  m_LocalRotation: {x: 0.05891734, y: 0.3960845, z: 0.010837861, w: 0.91625786}
   m_LocalPosition: {x: -0.21769282, y: -0.0063401023, z: -0.020410933}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -3280,7 +3279,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9185338537127686872}
-  m_LocalRotation: {x: 0.09833429, y: -0.080912486, z: 0.017980043, w: 0.9916957}
+  m_LocalRotation: {x: 0.091894925, y: -0.08039592, z: 0.016351724, w: 0.99238324}
   m_LocalPosition: {x: -0, y: 0.110377975, z: -0.0049123964}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:

--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -2200,7 +2200,7 @@ MonoBehaviour:
   model: {fileID: 2450014169262828258}
   IsOnGoal: 0
   IsInteractingWithAdvisor: 0
-  liftChargeFX: 0.5
+  liftChargeFX: 0
 --- !u!54 &-5524203305601732335
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -2182,7 +2182,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   dialogueCanvas: {fileID: 2082205148}
-  myModel: {fileID: 5006512736691705275}
+  myModel: {fileID: 1370749033330340325}
   runningVelocity: 3
   sprintVelocity: 4
   fallVelocityLimit: 10

--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -1243,6 +1243,37 @@ Transform:
   m_Father: {fileID: 5006512736691705275}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2450014169262828258
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1370749033330340325}
+  m_Layer: 0
+  m_Name: ModelParent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1370749033330340325
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2450014169262828258}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.072, y: 0.012, z: 0}
+  m_LocalScale: {x: 0.863937, y: 0.47999996, z: 0.863937}
+  m_Children:
+  - {fileID: 5006512736691705275}
+  m_Father: {fileID: 4839093188961784831}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2625202291296970219
 GameObject:
   m_ObjectHideFlags: 0
@@ -2035,7 +2066,7 @@ Transform:
   m_LocalPosition: {x: 1, y: 9.375, z: 0}
   m_LocalScale: {x: 0.6, y: 1.2, z: 1}
   m_Children:
-  - {fileID: 5006512736691705275}
+  - {fileID: 1370749033330340325}
   - {fileID: 2082205147}
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -2137,6 +2168,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   IsUsingXbox: 0
   IsInDialogue: 0
+  IsPaused: 0
 --- !u!114 &4839093188961784824
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2165,7 +2197,7 @@ MonoBehaviour:
   vertiRayMargin: 0.1
   vertiRayPadding: 0.1
   jumpToFallAnimationTime: 0.2
-  model: {fileID: 8296172667848665000}
+  model: {fileID: 2450014169262828258}
   IsOnGoal: 0
   IsInteractingWithAdvisor: 0
   liftChargeFX: 0.5
@@ -2976,13 +3008,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8296172667848665000}
-  m_LocalRotation: {x: -0, y: 0.76604444, z: -0, w: 0.64278764}
-  m_LocalPosition: {x: 0.012789383, y: -0.495, z: 0.098497}
-  m_LocalScale: {x: 0.863937, y: 0.47999996, z: 0.863937}
+  m_LocalRotation: {x: 0, y: 0.76604444, z: 0, w: 0.64278764}
+  m_LocalPosition: {x: -0.078709416, y: -1.0562497, z: 0.11400949}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 5357514018324747866}
   - {fileID: 5345838568456628042}
-  m_Father: {fileID: 4839093188961784831}
+  m_Father: {fileID: 1370749033330340325}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 100, z: 0}
 --- !u!95 &3166231814703347905

--- a/Assets/Scripts/Input/Player.cs
+++ b/Assets/Scripts/Input/Player.cs
@@ -44,7 +44,7 @@ public class Player : DialogueParticipant
     public float jumpToFallAnimationTime;
     private float lookRight = 0;
     private float lookLeft = 170;
-    private float lookAtCrowd = 185;
+    private float lookAtCrowd = 90;
     private bool isLookingRight = true;
     [SerializeField] private GameObject model;
 

--- a/Assets/Scripts/Input/Player.cs
+++ b/Assets/Scripts/Input/Player.cs
@@ -59,7 +59,6 @@ public class Player : DialogueParticipant
     //charge block
     public bool canDestroy { get; private set; } = true;
     private GameObject isChargingParticleEffect;
-    [SerializeField] private float liftChargeFX;
     #endregion
 
     #region Start, Update, onEnable
@@ -422,12 +421,8 @@ public class Player : DialogueParticipant
     private IEnumerator ChargeBlock(float time)
     {
         //charge effect
-        isChargingParticleEffect = Instantiate(EffectManager.Instance.GetEffect(11), model.transform, false);
-        isChargingParticleEffect.transform.Translate(0, liftChargeFX, 0);
-        Debug.Log("Charge effect info:");
-        Debug.Log("Position of model is: " + model.transform.position);
-        Debug.Log("Position of fx is: " + isChargingParticleEffect.transform.position);
-
+        isChargingParticleEffect = Instantiate(EffectManager.Instance.GetEffect(11), model.transform.position, new Quaternion(0,90,0,0), model.transform);
+        
         canDestroy = false;
         yield return new WaitForSeconds(time);
         canDestroy = true;

--- a/Assets/Scripts/Input/Player.cs
+++ b/Assets/Scripts/Input/Player.cs
@@ -42,8 +42,8 @@ public class Player : DialogueParticipant
     private static readonly int talkingParam = Animator.StringToHash("isTalking");
 
     public float jumpToFallAnimationTime;
-    private float lookRight = 100;
-    private float lookLeft = 270;
+    private float lookRight = 0;
+    private float lookLeft = 170;
     private float lookAtCrowd = 185;
     private bool isLookingRight = true;
     [SerializeField] private GameObject model;

--- a/Assets/Scripts/Input/Player.cs
+++ b/Assets/Scripts/Input/Player.cs
@@ -409,6 +409,12 @@ public class Player : DialogueParticipant
         animator.Play("Idle");
     }
 
+    public override void LookAtOther(DialogueParticipant otherPart)
+    {
+        base.LookAtOther(otherPart);
+        myModel.Rotate(-100 * Vector3.up);
+    }
+
     #endregion
 
     #region ChargeBlock


### PR DESCRIPTION
Fixed a collider consistency issue:

The model used to slip out of the collider.
Added a new empty object as parent of model in player prefab. This acts as an axis, so that the model can turn in the collider without slipping out.